### PR TITLE
Test that `ActiveRecordCoder` encodes attributes for database

### DIFF
--- a/test/activerecord/active_record_coder_test.rb
+++ b/test/activerecord/active_record_coder_test.rb
@@ -68,4 +68,11 @@ class PaquitoActiveRecordCodecTest < PaquitoTest
     end
     assert_equal "undefined association: foo", error.message
   end
+
+  test "works with json column with symbol keys assigned" do
+    extension = Extension.new(executable: { a: "b" })
+    codec_reloaded = @codec.load(@codec.dump(extension))
+
+    assert_equal({ "a" => "b" }, codec_reloaded.attributes["executable"])
+  end
 end

--- a/test/activerecord/support/models.rb
+++ b/test/activerecord/support/models.rb
@@ -20,6 +20,10 @@ ActiveRecord::Schema.define do
     t.references(:feature)
   end
 
+  create_table :extensions, force: true do |t|
+    t.json(:executable)
+  end
+
   create_table :products, force: true do |t|
     t.references(:shop)
     t.string(:name)
@@ -68,6 +72,9 @@ end
 
 class Domain < ActiveRecord::Base
   belongs_to :shop
+end
+
+class Extension < ActiveRecord::Base
 end
 
 online_store = Feature.create!(name: "Online Store")


### PR DESCRIPTION
`attributes_for_database` can be replaced with `attributes_before_type_cast` and all current tests will pass, although the change would break records which have been created with symbol-key-valued JSON column data (weird edge case, but it caused issues in core). I've added a model with a JSON column with data that has symbol-valued keys, and corresponding test which fails with `attributes_before_type_cast`, to avoid any regression, then we can remove all `ActiveRecordCoder` tests in Core.