### PR TITLE
Integrate Bigint support from msgpack master branch

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,8 @@ source "https://rubygems.org"
 # Specify your gem's dependencies in paquito.gemspec
 gemspec
 
+gem "msgpack", github: "msgpack/msgpack-ruby"
+
 gem "rake", "~> 13.0"
 gem "activesupport", ">= 7.0.0"
 gem "activerecord", ">= 7.0.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,9 @@
+GIT
+  remote: https://github.com/msgpack/msgpack-ruby.git
+  revision: 04ccbd8e11c894cbf235b497b2dbd93338a647b8
+  specs:
+    msgpack (1.4.5)
+
 PATH
   remote: .
   specs:
@@ -23,7 +29,6 @@ GEM
     i18n (1.9.1)
       concurrent-ruby (~> 1.0)
     minitest (5.14.4)
-    msgpack (1.4.4)
     parallel (1.21.0)
     parser (3.0.2.0)
       ast (~> 2.4.1)
@@ -61,6 +66,7 @@ DEPENDENCIES
   activesupport (>= 7.0.0)
   byebug
   minitest (~> 5.0)
+  msgpack!
   paquito!
   rake (~> 13.0)
   rubocop

--- a/lib/paquito/types.rb
+++ b/lib/paquito/types.rb
@@ -181,7 +181,21 @@ module Paquito
         unpacker: ->(factory, value) { factory.load(value).to_set },
       },
       # Object => { code: 0x7f }, reserved for serializable Object type
-    }.freeze
+    }
+    begin
+      require "msgpack/bigint"
+
+      TYPES["Integer"] = {
+        code: -122,
+        packer: MessagePack::Bigint.method(:to_msgpack_ext),
+        unpacker: MessagePack::Bigint.method(:from_msgpack_ext),
+        oversized_integer_extension: true,
+      }
+    rescue LoadError
+      # expected on older msgpack
+    end
+
+    TYPES.freeze
 
     class << self
       def register(factory, types)

--- a/test/vanilla/codec_factory_test.rb
+++ b/test/vanilla/codec_factory_test.rb
@@ -243,4 +243,12 @@ class PaquitoCodecFactoryTest < PaquitoTest
         "bigdecimal\xC7\n\x0427:0.123e3\xD6\x00hash\x81\xD4\x00a\x91\xD4\x00a".b
     ))
   end
+
+  if defined? MessagePack::Bigint
+    test "bigint support" do
+      @codec = Paquito::CodecFactory.build([Integer])
+      bigint = 2**150
+      assert_equal bigint, @codec.load(@codec.dump(bigint))
+    end
+  end
 end


### PR DESCRIPTION
Ref: https://github.com/msgpack/msgpack-ruby/pull/244

This allow to serialize arbitrary sized integer. The extension is only used if the integer doesn't fit in native msgpack types.