### PR TITLE
Integrate MessagePack pooling

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,6 +11,7 @@ gem "rake", "~> 13.0"
 gem "activesupport", ">= 7.0.0"
 gem "activerecord", ">= 7.0.0"
 gem "sqlite3"
+gem "benchmark-ips"
 
 gem "minitest", "~> 5.0"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -24,6 +24,7 @@ GEM
       minitest (>= 5.1)
       tzinfo (~> 2.0)
     ast (2.4.2)
+    benchmark-ips (2.10.0)
     byebug (11.1.3)
     concurrent-ruby (1.1.9)
     i18n (1.9.1)
@@ -64,6 +65,7 @@ PLATFORMS
 DEPENDENCIES
   activerecord (>= 7.0.0)
   activesupport (>= 7.0.0)
+  benchmark-ips
   byebug
   minitest (~> 5.0)
   msgpack!

--- a/benchmark/msgpack-pooling.rb
+++ b/benchmark/msgpack-pooling.rb
@@ -1,0 +1,19 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require "bundler/setup"
+require "paquito"
+require "benchmark/ips"
+
+BASELINE = Paquito::CodecFactory.build([Symbol], pool: false)
+POOLED = Paquito::CodecFactory.build([Symbol], pool: 1)
+
+PAYLOAD = BASELINE.dump(:foo)
+MARSHAL_PAYLOAD = Marshal.dump(:foo)
+
+Benchmark.ips do |x|
+  x.report("marshal") { Marshal.load(MARSHAL_PAYLOAD) }
+  x.report("msgpack") { BASELINE.load(PAYLOAD) }
+  x.report("pooled") { POOLED.load(PAYLOAD) }
+  x.compare!(order: :baseline)
+end

--- a/lib/paquito/types.rb
+++ b/lib/paquito/types.rb
@@ -220,6 +220,11 @@ module Paquito
         end
       end
 
+      def recursive?(type)
+        type_attributes = TYPES.fetch(type.name)
+        recursive_callback?(type_attributes[:packer]) || recursive_callback?(type_attributes[:unpacker])
+      end
+
       def register_serializable_type(factory)
         factory.register_type(
           0x7f,
@@ -249,6 +254,10 @@ module Paquito
       end
 
       private
+
+      def recursive_callback?(callback)
+        callback.respond_to?(:arity) && callback.arity != 1
+      end
 
       def curry_callback(callback, factory)
         return callback.to_proc if callback.is_a?(Symbol)

--- a/test/vanilla/codec_factory_test.rb
+++ b/test/vanilla/codec_factory_test.rb
@@ -4,7 +4,7 @@ require "test_helper"
 
 class PaquitoCodecFactoryTest < PaquitoTest
   def setup
-    @codec = Paquito::CodecFactory.build([Symbol, Time, DateTime, Date, BigDecimal])
+    @codec = Paquito::CodecFactory.build([Symbol, Time, DateTime, Date, BigDecimal], pool: 1)
   end
 
   test "correctly encodes Symbol objects" do


### PR DESCRIPTION
Ref: https://github.com/msgpack/msgpack-ruby/pull/266

```
Calculating -------------------------------------
             marshal      1.391M (± 1.3%) i/s -      6.958M in   5.001420s
             msgpack      1.494M (± 1.7%) i/s -      7.525M in   5.040000s
              pooled      2.224M (± 1.1%) i/s -     11.339M in   5.098817s

Comparison:
             marshal:  1391457.7 i/s
              pooled:  2224089.7 i/s - 1.60x  (± 0.00) faster
             msgpack:  1493576.4 i/s - 1.07x  (± 0.00) faster
```

The difference isn't as big (see: https://github.com/Shopify/paquito/pull/4) because I made lots of optimizations in `Packer` and `Unpacker` constructors, but it's still worth it I think.