### PR TITLE
Prevent Sorbet from storing incorrect ActiveSupport::TimeWithZone name

### DIFF
--- a/lib/paquito/types.rb
+++ b/lib/paquito/types.rb
@@ -206,11 +206,11 @@ module Paquito
     class << self
       def register(factory, types)
         types.each do |type|
-          name = type.name
-
           # Up to Rails 7 ActiveSupport::TimeWithZone#name returns "Time"
-          if name == "Time" && defined?(ActiveSupport::TimeWithZone)
-            name = "ActiveSupport::TimeWithZone" if type == ActiveSupport::TimeWithZone
+          name = if defined?(ActiveSupport::TimeWithZone) && type == ActiveSupport::TimeWithZone
+            "ActiveSupport::TimeWithZone"
+          else
+            type.name
           end
 
           type_attributes = TYPES.fetch(name)


### PR DESCRIPTION
If the Rails < 7.1 implementation of `ActiveSupport::TimeWithZone.name` is ever called during the loading process of a Sorbet-enabled project that uses `ActiveSupport::TimeWithZone`. When you create a union type like:

    MyTime = T.type_alias { T.any(Time, ActiveSupport::TimeWithZone) }

Sorbet memoizes this as "this type is either a `Time` or a `Time`", which leads to confusing messages like:

    TypeError: Return value: Expected type T.nilable(Time), got type
    Time with value 2022-05-06 15:30:00 +0000

This change ensures that Paquito never calls the bad implementation.

See [this treatise][1] that explains the issue in more detail or [this PR][2] for how we had to fix the issue elsewhere.

[1]: https://github.com/Shopify/arrive-server/commit/6f725f5e0dae4afe8af90cbf9c1822f34cd43dd9
[2]: https://github.com/Shopify/arrive-server/pull/34310