### PR TITLE
Update test suite to handle latest Psych error message

### DIFF
--- a/test/vanilla/safe_yaml_test.rb
+++ b/test/vanilla/safe_yaml_test.rb
@@ -30,7 +30,7 @@ class SafeYAMLTest < PaquitoTest
     error = assert_raises(Paquito::UnpackError) do
       @coder.load("<<: *foo")
     end
-    assert_equal "Unknown alias: foo", error.message
+    assert_includes ["Unknown alias: foo", "An alias referenced an unknown anchor: foo"], error.message
 
     assert_raises Paquito::UnpackError do
       @coder.load("*>>")


### PR DESCRIPTION
Ref: https://github.com/ruby/psych/pull/569