### PR TITLE
Introduce FlatCacheEntryCoder 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
 
+* Introduce `FlatCacheEntryCoder` (#21).
 * Drop the partial Ruby 2.6 support.
 
 # 0.8.0

--- a/README.md
+++ b/README.md
@@ -161,6 +161,28 @@ Example:
 ActiveSupport::Cache::FileStore.new("tmp/cache", coder: Paquito.chain(Paquito::CacheEntryCoder, JSON))
 ```
 
+### `FlatCacheEntryCoder`
+
+`Paquito::FlatCacheEntryCoder` is a variation of `Paquito::CacheEntryCoder`. Instead of encoding `ActiveSupport::Cache::Entry`
+into an Array of three members, it serializes the entry metadata itself and adds it as a prefix to the serialized payload.
+
+This allows to leverage `Paquito::SingleBytePrefixVersionWithStringBypass` effectively.
+
+Example:
+
+```ruby
+ActiveSupport::Cache::FileStore.new(
+  "tmp/cache",
+  coder: Paquito::FlatCacheEntryCoder.new(
+    Paquito::SingleBytePrefixVersionWithStringBypass.new(
+      1,
+      0 => Marshal,
+      1 => JSON,
+    )
+  )
+)
+```
+
 ### `SerializedColumn`
 
 `Paquito::SerializedColumn` allows you to decorate any encoder to behave like Rails's builtin `YAMLColumn`

--- a/benchmark/flat-entry-coder.rb
+++ b/benchmark/flat-entry-coder.rb
@@ -1,0 +1,51 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require "bundler/setup"
+require "paquito"
+require "active_support"
+require "benchmark/ips"
+
+CODEC = Paquito::CodecFactory.build([])
+ORIGINAL = Paquito::SingleBytePrefixVersion.new(
+  0,
+  0 => Paquito.chain(
+    Paquito::CacheEntryCoder,
+    CODEC,
+  ),
+)
+FLAT = Paquito::FlatCacheEntryCoder.new(
+  Paquito::SingleBytePrefixVersionWithStringBypass.new(
+    0,
+    0 => CODEC,
+  )
+)
+
+entries = {
+  small_string: "Hello World!",
+  bytes_1mb: Random.bytes(1_000_000),
+  int_array: 1000.times.to_a,
+  str_array: 1000.times.map(&:to_s),
+}
+
+entries.each do |name, object|
+  entry = ActiveSupport::Cache::Entry.new(object, expires_at: 15.minutes.from_now.to_f)
+  original_payload = ORIGINAL.dump(entry).freeze
+  flat_payload = FLAT.dump(entry).freeze
+
+  puts " === Read #{name} ==="
+  Benchmark.ips do |x|
+    x.report("original") { ORIGINAL.load(original_payload) }
+    x.report("flat") { FLAT.load(flat_payload) }
+    x.compare!(order: :baseline)
+  end
+
+  puts " === Write #{name} ==="
+  Benchmark.ips do |x|
+    x.report("original") { ORIGINAL.dump(entry) }
+    x.report("flat") { FLAT.dump(entry) }
+    x.compare!(order: :baseline)
+  end
+
+  puts
+end

--- a/benchmark/flat-entry-coder.rb
+++ b/benchmark/flat-entry-coder.rb
@@ -6,7 +6,7 @@ require "paquito"
 require "active_support"
 require "benchmark/ips"
 
-CODEC = Paquito::CodecFactory.build([])
+CODEC = Paquito::CodecFactory.build
 ORIGINAL = Paquito::SingleBytePrefixVersion.new(
   0,
   0 => Paquito.chain(
@@ -25,7 +25,6 @@ entries = {
   small_string: "Hello World!",
   bytes_1mb: Random.bytes(1_000_000),
   int_array: 1000.times.to_a,
-  str_array: 1000.times.map(&:to_s),
 }
 
 entries.each do |name, object|

--- a/lib/paquito.rb
+++ b/lib/paquito.rb
@@ -25,6 +25,7 @@ require "paquito/serialized_column"
 
 module Paquito
   autoload :CacheEntryCoder, "paquito/cache_entry_coder"
+  autoload :FlatCacheEntryCoder, "paquito/flat_cache_entry_coder"
   autoload :ActiveRecordCoder, "paquito/active_record_coder"
 
   class << self

--- a/lib/paquito/codec_factory.rb
+++ b/lib/paquito/codec_factory.rb
@@ -5,7 +5,7 @@ require "paquito/coder_chain"
 
 module Paquito
   class CodecFactory
-    def self.build(types, freeze: false, serializable_type: false, pool: 1)
+    def self.build(types = [], freeze: false, serializable_type: false, pool: 1)
       factory = if types.empty? && !serializable_type
         MessagePack::DefaultFactory
       else

--- a/lib/paquito/flat_cache_entry_coder.rb
+++ b/lib/paquito/flat_cache_entry_coder.rb
@@ -6,23 +6,43 @@ module Paquito
   class FlatCacheEntryCoder
     METADATA_CODEC = CodecFactory.build
 
+    EXPIRES_AT_FORMAT = "E" # Float double-precision, little-endian byte order (8 bytes)
+    VERSION_SIZE_FORMAT = "l<" # 32-bit signed, little-endian byte order (int32_t) (4 bytes)
+    PREFIX_FORMAT = -(EXPIRES_AT_FORMAT + VERSION_SIZE_FORMAT)
+    VERSION_SIZE_OFFSET = [0.0].pack(EXPIRES_AT_FORMAT).bytesize # should be 8
+    VERSION_OFFSET = [0.0, 0].pack(PREFIX_FORMAT).bytesize # Should be 12
+    VERSION_SIZE_UNPACK = -"@#{VERSION_SIZE_OFFSET}#{VERSION_SIZE_FORMAT}"
+
     def initialize(value_coder)
       @value_coder = value_coder
     end
 
     def dump(entry)
-      parts = entry.pack
-      value = parts.shift
-      metadata = METADATA_CODEC.dump(parts)
-      metadata.bytesize.chr(Encoding::BINARY) << metadata << @value_coder.dump(value)
+      version = entry.version
+      payload = [
+        entry.expires_at || 0.0,
+        version ? version.bytesize : -1,
+      ].pack(PREFIX_FORMAT)
+      payload << version if version
+      payload << @value_coder.dump(entry.value)
     end
 
     def load(payload)
-      metadata_size = payload.ord
-      parts = METADATA_CODEC.load(payload.byteslice(1, metadata_size))
-      value = @value_coder.load(payload.byteslice((metadata_size + 1)..-1))
-      parts.unshift(value)
-      ::ActiveSupport::Cache::Entry.unpack(parts)
+      expires_at = payload.unpack1(EXPIRES_AT_FORMAT)
+      expires_at = nil if expires_at == 0.0
+
+      version_size = payload.unpack1(VERSION_SIZE_UNPACK)
+      if version_size < 0
+        version_size = 0
+      else
+        version = payload.byteslice(VERSION_OFFSET, version_size)
+      end
+
+      ::ActiveSupport::Cache::Entry.new(
+        @value_coder.load(payload.byteslice((VERSION_OFFSET + version_size)..-1).freeze),
+        expires_at: expires_at,
+        version: version,
+      )
     end
   end
 end

--- a/lib/paquito/flat_cache_entry_coder.rb
+++ b/lib/paquito/flat_cache_entry_coder.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+gem "activesupport", ">= 7.0"
+
+module Paquito
+  class FlatCacheEntryCoder
+    METADATA_CODEC = CodecFactory.build
+
+    def initialize(value_coder)
+      @value_coder = value_coder
+    end
+
+    def dump(entry)
+      parts = entry.pack
+      value = parts.shift
+      metadata = METADATA_CODEC.dump(parts)
+      metadata.bytesize.chr(Encoding::BINARY) << metadata << @value_coder.dump(value)
+    end
+
+    def load(payload)
+      metadata_size = payload.ord
+      parts = METADATA_CODEC.load(payload.byteslice(1, metadata_size))
+      value = @value_coder.load(payload.byteslice((metadata_size + 1)..-1))
+      parts.unshift(value)
+      ::ActiveSupport::Cache::Entry.unpack(parts)
+    end
+  end
+end

--- a/test/activesupport/flat_cache_entry_coder_test.rb
+++ b/test/activesupport/flat_cache_entry_coder_test.rb
@@ -11,28 +11,28 @@ class FlatPaquitoCacheEntryCoderTest < PaquitoTest
 
   def test_simple_key
     @store.write("foo", "bar")
-    assert_equal "bar", @store.read("foo")
+    assert_equal("bar", @store.read("foo"))
     entry = read_entry("foo")
-    assert_nil entry.expires_at
-    assert_nil entry.version
+    assert_nil(entry.expires_at)
+    assert_nil(entry.version)
   end
 
   def test_simple_key_with_expriry
     @store.write("foo", "bar", expires_in: 5.minutes)
 
-    assert_equal "bar", @store.read("foo")
+    assert_equal("bar", @store.read("foo"))
     entry = read_entry("foo")
-    assert_in_delta 5.minutes.from_now.to_f, entry.expires_at, 0.5
-    assert_nil entry.version
+    assert_in_delta(5.minutes.from_now.to_f, entry.expires_at, 0.5)
+    assert_nil(entry.version)
   end
 
   def test_simple_key_with_version
     @store.write("foo", "bar", version: "v1")
 
-    assert_equal "bar", @store.read("foo")
+    assert_equal("bar", @store.read("foo"))
     entry = read_entry("foo")
-    assert_nil entry.expires_at
-    assert_equal "v1", entry.version
+    assert_nil(entry.expires_at)
+    assert_equal("v1", entry.version)
   end
 
   private

--- a/test/activesupport/flat_cache_entry_coder_test.rb
+++ b/test/activesupport/flat_cache_entry_coder_test.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class FlatPaquitoCacheEntryCoderTest < PaquitoTest
+  def setup
+    @coder = Paquito::FlatCacheEntryCoder.new(JSON)
+    @cache_dir = Dir.mktmpdir
+    @store = ActiveSupport::Cache::FileStore.new(@cache_dir, coder: @coder)
+  end
+
+  def test_simple_key
+    @store.write("foo", "bar")
+    assert_equal "bar", @store.read("foo")
+    entry = read_entry("foo")
+    assert_nil entry.expires_at
+    assert_nil entry.version
+  end
+
+  def test_simple_key_with_expriry
+    @store.write("foo", "bar", expires_in: 5.minutes)
+
+    assert_equal "bar", @store.read("foo")
+    entry = read_entry("foo")
+    assert_in_delta 5.minutes.from_now.to_f, entry.expires_at, 0.5
+    assert_nil entry.version
+  end
+
+  def test_simple_key_with_version
+    @store.write("foo", "bar", version: "v1")
+
+    assert_equal "bar", @store.read("foo")
+    entry = read_entry("foo")
+    assert_nil entry.expires_at
+    assert_equal "v1", entry.version
+  end
+
+  private
+
+  def read_entry(key)
+    @store.send(:read_entry, @store.send(:normalize_key, key, {}))
+  end
+
+  def raw_cache_read(key)
+    File.read(Dir[File.join(@cache_dir, "**", key)].first)
+  end
+end


### PR DESCRIPTION
Followup: https://github.com/Shopify/paquito/pull/20

This new coder move the entry metadata (expires_at, version) out of the payload.

This then allow SingleBytePrefixVersionWithStringBypass to actually use its fastpath when the cache value is a String.

It's only on reads that we really gain because Ruby use copy on write to extract the string, on write we have to copy the string to add the metadata prefix, so on larger strings the gain is marginal.

```
 === Read small_string ===
Warming up --------------------------------------
            original   120.838k i/100ms
                flat   154.942k i/100ms
Calculating -------------------------------------
            original      1.216M (± 0.6%) i/s -      6.163M in   5.069546s
                flat      1.545M (± 0.8%) i/s -      7.747M in   5.013333s

Comparison:
            original:  1215684.5 i/s
                flat:  1545402.6 i/s - 1.27x  (± 0.00) faster

 === Write small_string ===
Warming up --------------------------------------
            original   139.381k i/100ms
                flat   228.295k i/100ms
Calculating -------------------------------------
            original      1.453M (± 0.9%) i/s -      7.387M in   5.085226s
                flat      2.266M (± 1.2%) i/s -     11.415M in   5.037101s

Comparison:
            original:  1452805.7 i/s
                flat:  2266467.9 i/s - 1.56x  (± 0.00) faster

 === Read bytes_1mb ===
Warming up --------------------------------------
            original     1.050k i/100ms
                flat   143.636k i/100ms
Calculating -------------------------------------
            original     10.853k (± 7.0%) i/s -     54.600k in   5.060952s
                flat      1.408M (± 1.7%) i/s -      7.182M in   5.101544s

Comparison:
            original:    10853.0 i/s
                flat:  1408188.3 i/s - 129.75x  (± 0.00) faster

 === Write bytes_1mb ===
Warming up --------------------------------------
            original   495.000  i/100ms
                flat   485.000  i/100ms
Calculating -------------------------------------
            original      4.971k (± 4.1%) i/s -     25.245k in   5.087300s
                flat      4.846k (± 3.1%) i/s -     24.250k in   5.009118s

Comparison:
            original:     4970.6 i/s
                flat:     4845.8 i/s - same-ish: difference falls within error

 === Read int_array ===
Warming up --------------------------------------
            original    10.176k i/100ms
                flat    10.220k i/100ms
Calculating -------------------------------------
            original    102.780k (± 1.6%) i/s -    518.976k in   5.050664s
                flat    101.501k (± 1.6%) i/s -    511.000k in   5.035762s

Comparison:
            original:   102780.1 i/s
                flat:   101501.4 i/s - same-ish: difference falls within error

 === Write int_array ===
Warming up --------------------------------------
            original    14.880k i/100ms
                flat    14.600k i/100ms
Calculating -------------------------------------
            original    153.837k (± 2.1%) i/s -    773.760k in   5.031850s
                flat    146.851k (± 3.0%) i/s -    744.600k in   5.074899s

Comparison:
            original:   153837.0 i/s
                flat:   146851.2 i/s - same-ish: difference falls within error
```
