### PR TITLE
Fix a bug introduced by compress / decompress handler, and bump version to 0.9.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Unreleased
 
+# 0.9.1
+
+* Fix a bug when handle `compress / decompress` coders. (#23)
 * `SingleBytePrefixVersionWithStringBypass` accepts another coder for strings.
 
 # 0.9.0

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    paquito (0.9.0)
+    paquito (0.9.1)
       msgpack (>= 1.5.2)
 
 GEM

--- a/lib/paquito.rb
+++ b/lib/paquito.rb
@@ -10,6 +10,7 @@ require "msgpack"
 
 require "paquito/version"
 require "paquito/deflater"
+require "paquito/compressor"
 require "paquito/allow_nil"
 require "paquito/translate_errors"
 require "paquito/safe_yaml"

--- a/lib/paquito/version.rb
+++ b/lib/paquito/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Paquito
-  VERSION = "0.9.0"
+  VERSION = "0.9.1"
 end


### PR DESCRIPTION
Fix the following errors:

```
Traceback (most recent call last):
	9: from bench.rb:154:in `<main>'
	8: from bench.rb:154:in `new'
	7: from bench.rb:78:in `initialize'
	6: from /opt/rubies/2.7.5/lib/ruby/site_ruby/2.7.0/rubygems/core_ext/kernel_require.rb:85:in `require'
	5: from /opt/rubies/2.7.5/lib/ruby/site_ruby/2.7.0/rubygems/core_ext/kernel_require.rb:85:in `require'
	4: from /Users/jchome/src/github.com/Shopify/caching-platform/bench-compression/compressor_marshal.rb:5:in `<top (required)>'
	3: from /Users/jchome/src/github.com/Shopify/caching-platform/bench-compression/compressor_marshal.rb:20:in `<module:Coder>'
	2: from /Users/jchome/src/github.com/Shopify/caching-platform/bench-compression/compressor_marshal.rb:20:in `new'
	1: from /Users/jchome/.gem/ruby/2.7.5/gems/paquito-0.9.0/lib/paquito/conditional_compressor.rb:9:in `initialize'
/Users/jchome/.gem/ruby/2.7.5/gems/paquito-0.9.0/lib/paquito.rb:38:in `cast': uninitialized constant #<Class:Paquito>::Compressor (NameError)
```