### PR TITLE
Time type: avoid mutating the serialized object

### DIFF
--- a/lib/paquito/types.rb
+++ b/lib/paquito/types.rb
@@ -82,7 +82,7 @@ module Paquito
       "Time" => {
         code: 1,
         packer: ->(value) do
-          rational = value.utc.to_r
+          rational = value.to_r
           [rational.numerator, rational.denominator].pack(TIME_FORMAT)
         end,
         unpacker: ->(value) do

--- a/test/vanilla/codec_factory_test.rb
+++ b/test/vanilla/codec_factory_test.rb
@@ -25,6 +25,14 @@ class PaquitoCodecFactoryTest < PaquitoTest
     assert_equal(value, recovered_value)
   end
 
+  test "does not mutate Time objects" do
+    time = Time.at(1_671_439_400, in: "+12:30")
+    time_state = time.inspect
+    assert_equal time_state, time.inspect
+    @codec.dump(time)
+    assert_equal time_state, time.inspect
+  end
+
   test "correctly encodes DateTime objects" do
     codec = Paquito::CodecFactory.build([DateTime])
 


### PR DESCRIPTION
`Time#offset` mutates the reciever which is a big no-no.

But it has no impact on `Time#to_r`, so we can just not call it.

```ruby
>> Time.at(1_000_000, in: "+12:30").to_r ==  Time.at(1_000_000, in: "+00:00").to_r
=> true
```

FYI @shioyama 

Also I think we should persist the timezone too. I'll look into it in a followup, but we need to do it in a forward compatible way.