### PR TITLE
Introduce new packers for Time, DateTime and AS::TimeWithZone

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -6,3 +6,6 @@ AllCops:
 
 Style/ClassMethodsDefinitions:
   Enabled: false
+
+Style/DateTime:
+  Enabled: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Unreleased
 
+* Introduce a new version `1` format that better handles `Time` and `DateTime` objects. It can be enabled by setting `Paquito.format_version = 1`.
+  *IMPORTANT*: If you are upgrading from previous versions, you MUST first fully deploy the new version of the gem prior to enabling the new format.
+  If you don't you may notice some `UnpackError` during the code rollout, which may be fine if you only use Paquito for ephemeral cache data.
+
+  *This new format will be the default in paquito 1.0.*
 
 # 0.9.2
 

--- a/README.md
+++ b/README.md
@@ -18,6 +18,25 @@ Or install it yourself as:
 
     $ gem install paquito
 
+## Upgrade process
+
+`Paquito` being a serialization library, takes extra care in always being able to deserialize payloads serialized from previous versions.
+
+However the inverse may not always be true, so when upgrading `Paquito` it is essential to first upgrade the gem without any applicative code change, so
+that all Ruby processes in production are able to read the new format.
+
+Additionally format changes can be controlled through `Paquito.format_version` that directly maps with the gem major version.
+
+For example, `paquito 0.10.0` introduce a new serialization format for `Time` and `DateTime` objects, but retain `Paquito.format_version = 0`.
+
+The upgrade process is as follows:
+
+  - Upgrade to `paquito ~> 0.10`.
+  - Fully deploy that upgrade (if multiple applications are sharing Paquito payloads it means upgrading all the applications).
+  - Set `Paquito.format_version = 1` or upgrade to `paquito ~> 1.0`.
+
+Generally speaking it's heavily recommended to carefully read the CHANGELOG and not to skip intermediary versions.
+
 ## Usage
 
 ### `chain`

--- a/lib/paquito.rb
+++ b/lib/paquito.rb
@@ -29,7 +29,12 @@ module Paquito
   autoload :FlatCacheEntryCoder, "paquito/flat_cache_entry_coder"
   autoload :ActiveRecordCoder, "paquito/active_record_coder"
 
+  DEFAULT_FORMAT_VERSION = 0
+  @format_version = DEFAULT_FORMAT_VERSION
+
   class << self
+    attr_accessor :format_version
+
     def cast(coder)
       if coder.respond_to?(:load) && coder.respond_to?(:dump)
         coder

--- a/lib/paquito/codec_factory.rb
+++ b/lib/paquito/codec_factory.rb
@@ -5,14 +5,14 @@ require "paquito/coder_chain"
 
 module Paquito
   class CodecFactory
-    def self.build(types = [], freeze: false, serializable_type: false, pool: 1)
+    def self.build(types = [], freeze: false, serializable_type: false, pool: 1, format_version: Paquito.format_version)
       factory = if types.empty? && !serializable_type
         MessagePack::DefaultFactory
       else
         MessagePack::Factory.new
       end
 
-      Types.register(factory, types) unless types.empty?
+      Types.register(factory, types, format_version: format_version) unless types.empty?
       Types.register_serializable_type(factory) if serializable_type
 
       if pool && pool > 0 && factory.respond_to?(:pool)

--- a/lib/paquito/types.rb
+++ b/lib/paquito/types.rb
@@ -12,6 +12,9 @@ module Paquito
     DATE_TIME_FORMAT = "s< C C C C q< L< c C"
     DATE_FORMAT = "s< C C"
 
+    MAX_UINT32 = (2**32) - 1
+    MAX_INT64 = (2**63) - 1
+
     SERIALIZE_METHOD = :as_pack
     SERIALIZE_PROC = SERIALIZE_METHOD.to_proc
     DESERIALIZE_METHOD = :from_pack
@@ -72,29 +75,53 @@ module Paquito
 
     # Do not change any #code, this would break current codecs.
     # New types can be added as long as they have unique #code.
-    TYPES = {
-      "Symbol" => {
+    TYPES = [
+      {
         code: 0,
+        class: "Symbol",
+        version: 0,
         packer: Symbol.method_defined?(:name) ? :name.to_proc : :to_s.to_proc,
         unpacker: :to_sym.to_proc,
         optimized_symbols_parsing: true,
       }.freeze,
-      "Time" => {
+      {
         code: 1,
+        class: "Time",
+        version: 0,
         packer: ->(value) do
           rational = value.to_r
+          if rational.numerator > MAX_INT64 || rational.denominator > MAX_UINT32
+            raise PackError, "Time instance out of bounds (#{rational.inspect}), see: https://github.com/Shopify/paquito/issues/26"
+          end
+
           [rational.numerator, rational.denominator].pack(TIME_FORMAT)
         end,
         unpacker: ->(value) do
           numerator, denominator = value.unpack(TIME_FORMAT)
-          Time.at(Rational(numerator, denominator)).utc
+          at = begin
+            Rational(numerator, denominator)
+          rescue ZeroDivisionError
+            raise UnpackError, "Corrupted Time object, see: https://github.com/Shopify/paquito/issues/26"
+          end
+          Time.at(at).utc
         end,
       }.freeze,
-      "DateTime" => {
+      {
         code: 2,
+        class: "DateTime",
+        version: 0,
         packer: ->(value) do
           sec = value.sec + value.sec_fraction
           offset = value.offset
+
+          if sec.numerator > MAX_INT64 || sec.denominator > MAX_UINT32
+            raise PackError, "DateTime#sec_fraction out of bounds (#{sec.inspect}), see: https://github.com/Shopify/paquito/issues/26"
+          end
+
+          if offset.numerator > MAX_INT64 || offset.denominator > MAX_UINT32
+            raise PackError, "DateTime#offset out of bounds (#{offset.inspect}), see: https://github.com/Shopify/paquito/issues/26"
+          end
+
           [
             value.year,
             value.month,
@@ -119,40 +146,53 @@ module Paquito
             offset_numerator,
             offset_denominator,
           ) = value.unpack(DATE_TIME_FORMAT)
-          DateTime.new( # rubocop:disable Style/DateTime
-            year,
-            month,
-            day,
-            hour,
-            minute,
-            Rational(sec_numerator, sec_denominator),
-            Rational(offset_numerator, offset_denominator),
-          )
+
+          begin
+            ::DateTime.new(
+              year,
+              month,
+              day,
+              hour,
+              minute,
+              Rational(sec_numerator, sec_denominator),
+              Rational(offset_numerator, offset_denominator),
+            )
+          rescue ZeroDivisionError
+            raise UnpackError, "Corrupted DateTime object, see: https://github.com/Shopify/paquito/issues/26"
+          end
         end,
       }.freeze,
-      "Date" => {
+      {
         code: 3,
+        class: "Date",
+        version: 0,
         packer: ->(value) do
           [value.year, value.month, value.day].pack(DATE_FORMAT)
         end,
         unpacker: ->(value) do
           year, month, day = value.unpack(DATE_FORMAT)
-          Date.new(year, month, day)
+          ::Date.new(year, month, day)
         end,
       }.freeze,
-      "BigDecimal" => {
+      {
         code: 4,
+        class: "BigDecimal",
+        version: 0,
         packer: :_dump,
-        unpacker: BigDecimal.method(:_load),
+        unpacker: ::BigDecimal.method(:_load),
       }.freeze,
-      # Range => { code: 0x05 }, do not recycle that code
-      "ActiveRecord::Base" => {
+      # { code: 5, class: "Range" }, do not recycle that code
+      {
         code: 6,
+        class: "ActiveRecord::Base",
+        version: 0,
         packer: ->(value) { ActiveRecordPacker.dump(value) },
         unpacker: ->(value) { ActiveRecordPacker.load(value) },
       }.freeze,
-      "ActiveSupport::HashWithIndifferentAccess" => {
+      {
         code: 7,
+        class: "ActiveSupport::HashWithIndifferentAccess",
+        version: 0,
         packer: ->(value, packer) do
           unless value.instance_of?(ActiveSupport::HashWithIndifferentAccess)
             raise PackError.new("cannot pack HashWithIndifferentClass subclass", value)
@@ -162,9 +202,11 @@ module Paquito
         end,
         unpacker: ->(unpacker) { ActiveSupport::HashWithIndifferentAccess.new(unpacker.read) },
         recursive: true,
-      },
-      "ActiveSupport::TimeWithZone" => {
+      }.freeze,
+      {
         code: 8,
+        class: "ActiveSupport::TimeWithZone",
+        version: 0,
         packer: ->(value) do
           [
             value.utc.to_i,
@@ -178,21 +220,88 @@ module Paquito
           time_zone = ::Time.find_zone(time_zone_name)
           ActiveSupport::TimeWithZone.new(time, time_zone)
         end,
-      },
-      "Set" => {
+      }.freeze,
+      {
         code: 9,
+        class: "Set",
+        version: 0,
         packer: ->(value, packer) { packer.write(value.to_a) },
         unpacker: ->(unpacker) { unpacker.read.to_set },
         recursive: true,
-      },
-      # Integer => { code: 10 }, reserved for oversized Integer
-      # Object => { code: 127 }, reserved for serializable Object type
-    }
+      }.freeze,
+      # { code: 10, class: "Integer" }, reserved for oversized Integer
+      {
+        code: 11,
+        class: "Time",
+        version: 1,
+        recursive: true,
+        packer: ->(value, packer) do
+          packer.write(value.tv_sec)
+          packer.write(value.tv_nsec)
+          packer.write(value.utc_offset)
+        end,
+        unpacker: ->(unpacker) do
+          ::Time.at(unpacker.read, unpacker.read, :nanosecond, in: unpacker.read)
+        end,
+      }.freeze,
+      {
+        code: 12,
+        class: "DateTime",
+        version: 1,
+        recursive: true,
+        packer: ->(value, packer) do
+          packer.write(value.year)
+          packer.write(value.month)
+          packer.write(value.day)
+          packer.write(value.hour)
+          packer.write(value.minute)
+
+          sec = value.sec + value.sec_fraction
+          packer.write(sec.numerator)
+          packer.write(sec.denominator)
+
+          offset = value.offset
+          packer.write(offset.numerator)
+          packer.write(offset.denominator)
+        end,
+        unpacker: ->(unpacker) do
+          ::DateTime.new(
+            unpacker.read, # year
+            unpacker.read, # month
+            unpacker.read, # day
+            unpacker.read, # hour
+            unpacker.read, # minute
+            Rational(unpacker.read, unpacker.read), # sec fraction
+            Rational(unpacker.read, unpacker.read), # offset fraction
+          )
+        end,
+      }.freeze,
+      {
+        code: 13,
+        class: "ActiveSupport::TimeWithZone",
+        version: 1,
+        recursive: true,
+        packer: ->(value, packer) do
+          time = value.utc
+          packer.write(time.tv_sec)
+          packer.write(time.tv_nsec)
+          packer.write(value.time_zone.name)
+        end,
+        unpacker: ->(unpacker) do
+          utc = ::Time.at(unpacker.read, unpacker.read, :nanosecond, in: "UTC")
+          time_zone = ::Time.find_zone(unpacker.read)
+          ActiveSupport::TimeWithZone.new(utc, time_zone)
+        end,
+      }.freeze,
+      # { code: 127, class: "Object" }, reserved for serializable Object type
+    ]
     begin
       require "msgpack/bigint"
 
-      TYPES["Integer"] = {
+      TYPES << {
         code: 10,
+        class: "Integer",
+        version: 0,
         packer: MessagePack::Bigint.method(:to_msgpack_ext),
         unpacker: MessagePack::Bigint.method(:from_msgpack_ext),
         oversized_integer_extension: true,
@@ -204,7 +313,7 @@ module Paquito
     TYPES.freeze
 
     class << self
-      def register(factory, types)
+      def register(factory, types, format_version: Paquito.format_version)
         types.each do |type|
           # Up to Rails 7 ActiveSupport::TimeWithZone#name returns "Time"
           name = if defined?(ActiveSupport::TimeWithZone) && type == ActiveSupport::TimeWithZone
@@ -213,18 +322,29 @@ module Paquito
             type.name
           end
 
-          type_attributes = TYPES.fetch(name)
-          factory.register_type(
-            type_attributes.fetch(:code),
-            type,
-            type_attributes,
-          )
+          matching_types = TYPES.select { |t| t[:class] == name }
+
+          # If multiple types are registered for the same class, the last one will be used for
+          # packing. So we sort all matching types so that the active one is registered last.
+          past_types, future_types = matching_types.partition { |t| t.fetch(:version) <= format_version }
+          if past_types.empty?
+            raise KeyError, "No type found for #{name.inspect} with format_version=#{format_version}"
+          end
+
+          past_types.sort_by! { |t| t.fetch(:version) }
+          (future_types + past_types).each do |type_attributes|
+            factory.register_type(
+              type_attributes.fetch(:code),
+              type,
+              type_attributes,
+            )
+          end
         end
       end
 
       def register_serializable_type(factory)
         factory.register_type(
-          0x7f,
+          127,
           Object,
           packer: ->(value) do
             packer = CustomTypesRegistry.packer(value)

--- a/test/vanilla/codec_factory_test.rb
+++ b/test/vanilla/codec_factory_test.rb
@@ -2,261 +2,312 @@
 
 require "test_helper"
 
-class PaquitoCodecFactoryTest < PaquitoTest
-  def setup
-    @codec = Paquito::CodecFactory.build([Symbol, Time, DateTime, Date, BigDecimal], pool: 1)
-  end
+module Paquito
+  module SharedCodecFactoryTests
+    # The difference is in the prefix which contains details about the internal representation (27 vs 9).
+    # However both versions can read each others fine, so it's not a problem.
+    RUBY_3_0_BIG_DECIMAL = "\xC7\n\x0427:0.123e3".b.freeze
+    RUBY_3_1_BIG_DECIMAL = "\xC7\t\x049:0.123e3".b.freeze
+    BIG_DECIMAL_PAYLOAD = RUBY_VERSION >= "3.1" ? RUBY_3_1_BIG_DECIMAL : RUBY_3_0_BIG_DECIMAL
 
-  test "correctly encodes Symbol objects" do
-    codec = Paquito::CodecFactory.build([Symbol])
-
-    assert_equal("\xC7\x05\x00hello".b, codec.dump(:hello))
-    assert_equal(:hello, codec.load(codec.dump(:hello)))
-  end
-
-  test "correctly encodes Time objects" do
-    codec = Paquito::CodecFactory.build([Time])
-
-    value = Time.at(Rational(1_486_570_508_539_759, 1_000_000)).utc
-    encoded_value = codec.dump(value)
-    assert_equal("\xC7\f\x01oW\x18+\aH\x05\x00@B\x0F\x00".b, encoded_value)
-    recovered_value = codec.load(encoded_value)
-    assert_equal(value.nsec, recovered_value.nsec)
-    assert_equal(value, recovered_value)
-  end
-
-  test "does not mutate Time objects" do
-    time = Time.at(1_671_439_400, in: "+12:30")
-    time_state = time.inspect
-    assert_equal time_state, time.inspect
-    @codec.dump(time)
-    assert_equal time_state, time.inspect
-  end
-
-  test "correctly encodes DateTime objects" do
-    codec = Paquito::CodecFactory.build([DateTime])
-
-    value = DateTime.new(2017, 2, 8, 11, 25, 12.571685, "EST") # rubocop:disable Style/DateTime
-    encoded_value = codec.dump(value)
-    assert_equal("\xC7\x14\x02\xE1\a\x02\b\v\x19\xA1]&\x00\x00\x00\x00\x00@\r\x03\x00\xFB\x18".b, encoded_value)
-    assert_equal(value, codec.load(encoded_value))
-  end
-
-  test "correctly encodes Date objects" do
-    codec = Paquito::CodecFactory.build([Date])
-
-    value = Date.new(2017, 2, 8)
-    encoded_value = codec.dump(value)
-    assert_equal("\xD6\x03\xE1\a\x02\b".b, encoded_value)
-    recovered_value = codec.load(encoded_value)
-    assert_equal(value, recovered_value)
-  end
-
-  # The difference is in the prefix which contains details about the internal representation (27 vs 9).
-  # However both versions can read each others fine, so it's not a problem.
-  RUBY_3_0_BIG_DECIMAL = "\xC7\n\x0427:0.123e3".b.freeze
-  RUBY_3_1_BIG_DECIMAL = "\xC7\t\x049:0.123e3".b.freeze
-  BIG_DECIMAL_PAYLOAD = RUBY_VERSION >= "3.1" ? RUBY_3_1_BIG_DECIMAL : RUBY_3_0_BIG_DECIMAL
-
-  test "BigDecimal serialization is stable" do
-    assert_equal(
-      BIG_DECIMAL_PAYLOAD,
-      @codec.dump(BigDecimal(123)),
-    )
-
-    assert_equal(
-      BigDecimal(123),
-      @codec.load(RUBY_3_0_BIG_DECIMAL),
-    )
-
-    assert_equal(
-      BigDecimal(123),
-      @codec.load(RUBY_3_1_BIG_DECIMAL),
-    )
-  end
-
-  test "reject malformed payloads with Paquito::PackError" do
-    assert_raises Paquito::UnpackError do
-      @codec.load("\x00\x00")
-    end
-  end
-
-  test "correctly encodes BigDecimal objects" do
-    codec = Paquito::CodecFactory.build([BigDecimal])
-
-    value = BigDecimal("123456789123456789.123456789123456789")
-    encoded_value = codec.dump(value)
-    assert_equal("\xC7,\x0445:0.123456789123456789123456789123456789e18".b, encoded_value)
-    recovered_value = codec.load(encoded_value)
-    assert_equal(value, recovered_value)
-  end
-
-  test "correctly encodes Set objects" do
-    codec = Paquito::CodecFactory.build([Set])
-
-    value = Set.new([1, 2, [3, 4, Set.new([5])]])
-    encoded_value = codec.dump(value)
-    assert_equal "\xC7\n\t\x93\x01\x02\x93\x03\x04\xD5\t\x91\x05".b, encoded_value
-
-    recovered_value = codec.load(encoded_value)
-    assert_equal(value, recovered_value)
-  end
-
-  test "supports freeze on load" do
-    # without extra types
-    codec = Paquito::CodecFactory.build([])
-    assert_equal(false, codec.load(codec.dump("foo")).frozen?)
-
-    codec = Paquito::CodecFactory.build([], freeze: true)
-    assert_equal(true, codec.load(codec.dump("foo")).frozen?)
-
-    # with extra types
-    codec = Paquito::CodecFactory.build([BigDecimal])
-    assert_equal(false, codec.load(codec.dump("foo")).frozen?)
-
-    codec = Paquito::CodecFactory.build([BigDecimal], freeze: true)
-    assert_equal(true, codec.load(codec.dump("foo")).frozen?)
-  end
-
-  test "does not enforce strictness of Hash type without serializable_type option" do
-    codec = Paquito::CodecFactory.build([])
-
-    type_subclass = Class.new(Hash)
-    object = type_subclass.new
-
-    assert_equal Hash, codec.load(codec.dump(object)).class
-  end
-
-  test "enforces strictness of Hash type with serializable_type option" do
-    codec = Paquito::CodecFactory.build([], serializable_type: true)
-
-    type_subclass = Class.new(Hash)
-    object = type_subclass.new
-
-    assert_raises(Paquito::PackError) { codec.dump(object) }
-  end
-
-  test "rejects unknown types with Paquito::PackError" do
-    codec = Paquito::CodecFactory.build([])
-    assert_raises(Paquito::PackError) do
-      codec.dump(Time.now)
-    end
-  end
-
-  test "rejects undeclared types with serializable_type option" do
-    codec = Paquito::CodecFactory.build([], serializable_type: true)
-
-    undeclared_type = Class.new(Object) do
-      def to_msgpack(_)
-      end
-    end
-    object = undeclared_type.new
-
-    assert_raises(Paquito::PackError) { codec.dump(object) }
-  end
-
-  ObjectOne = Struct.new(:foo, :bar) do
-    def as_pack
-      [foo, bar]
-    end
-
-    def self.from_pack(payload)
-      new(*payload)
-    end
-  end
-
-  ObjectTwo = Struct.new(:baz, :qux) do
-    def as_pack
-      members.zip(values).to_h
-    end
-
-    def self.from_pack(payload)
-      new(payload[:baz], payload[:qux])
-    end
-  end
-
-  test "serializes any object defining Object#as_pack and Object.from_pack with serializable_type option" do
-    codec = Paquito::CodecFactory.build([Symbol], serializable_type: true)
-
-    object = ObjectOne.new(
-      "foo",
-      { "bar" => ObjectTwo.new("baz", "qux") },
-    )
-    decoded = codec.load(codec.dump(object))
-    assert_equal object, decoded
-  end
-
-  test "handles class name changes by raising defined exception" do
-    codec = Paquito::CodecFactory.build([Symbol], serializable_type: true)
-
-    klass = ObjectOne
-    object = ObjectOne.new("foo", "bar")
-    serial = codec.dump(object)
-
-    begin
-      self.class.send(:remove_const, :ObjectOne)
-      assert_raises(Paquito::ClassMissingError) do
-        codec.load(serial)
-      end
-    ensure
-      self.class.const_set(:ObjectOne, klass) unless self.class.const_defined?(:ObjectOne)
-    end
-  end
-
-  test "MessagePack errors are encapsulated" do
-    error = assert_raises(Paquito::PackError) do
-      @codec.dump(2**128)
-    end
-    assert_equal "RangeError, bignum too big to convert into `unsigned long long'", error.message
-
-    payload = @codec.dump("foo")
-    error = assert_raises(Paquito::UnpackError) do
-      @codec.load(payload.byteslice(0..-2))
-    end
-    assert_equal "EOFError, end of buffer reached", error.message
-  end
-
-  test "all types are stable together" do
-    assert_equal(
-      "\x87\xC7\x06\x00symbol\xC7\x06\x00symbol\xC7\x06\x00string\xA6string\xC7\x05\x00array\x92\xD4\x00a\xA1b" \
-        "\xD6\x00time\xC7\f\x01\x1A`m8\x00\x00\x00\x00\x01\x00\x00\x00\xD7\x00datetime\xC7\x14\x02\xD0\a\x01\x01\x04" \
-        "\x05\x06\x00\x00\x00\x00\x00\x00\x00\x01\x00\x00\x00\x00\x01\xD6\x00date\xD6\x03\xD0\a\x01\x01\xD6\x00hash" \
-        "\x81\xD4\x00a\x91\xD4\x00a".b,
-      @codec.dump(
-        symbol: :symbol,
-        string: "string",
-        array: [:a, "b"],
-        time: Time.new(2000, 1, 1, 2, 2, 2, "+00:00"),
-        datetime: DateTime.new(2000, 1, 1, 4, 5, 6, "UTC"), # rubocop:disable Style/DateTime
-        date: Date.new(2000, 1, 1),
-        hash: { a: [:a] },
-      ),
-    )
-
-    expected = {
+    OBJECTS = {
       symbol: :symbol,
       string: "string",
       array: [:a, "b"],
       time: Time.new(2000, 1, 1, 2, 2, 2, "+00:00"),
-      datetime: DateTime.new(2000, 1, 1, 4, 5, 6, "UTC"), # rubocop:disable Style/DateTime
+      datetime: DateTime.new(2000, 1, 1, 4, 5, 6, "UTC"),
       date: Date.new(2000, 1, 1),
-      bigdecimal: BigDecimal(123),
       hash: { a: [:a] },
-    }
+    }.freeze
+    V0_PAYLOAD = "\x87\xC7\x06\x00symbol\xC7\x06\x00symbol\xC7\x06\x00string\xA6string\xC7\x05\x00array\x92" \
+      "\xD4\x00a\xA1b\xD6\x00time\xC7\f\x01\x1A`m8\x00\x00\x00\x00\x01\x00\x00\x00\xD7\x00datetime\xC7\x14" \
+      "\x02\xD0\a\x01\x01\x04\x05\x06\x00\x00\x00\x00\x00\x00\x00\x01\x00\x00\x00\x00\x01\xD6\x00date\xD6" \
+      "\x03\xD0\a\x01\x01\xD6\x00hash\x81\xD4\x00a\x91\xD4\x00a".b.freeze
 
-    assert_equal(expected, @codec.load(
-      "\x88\xC7\x06\x00symbol\xC7\x06\x00symbol\xC7\x06\x00string\xA6string\xC7\x05\x00array\x92\xD4\x00a\xA1b" \
-        "\xD6\x00time\xC7\f\x01\x1A`m8\x00\x00\x00\x00\x01\x00\x00\x00\xD7\x00datetime\xC7\x14\x02\xD0\a\x01\x01\x04" \
-        "\x05\x06\x00\x00\x00\x00\x00\x00\x00\x01\x00\x00\x00\x00\x01\xD6\x00date\xD6\x03\xD0\a\x01\x01\xC7\n\x00" \
-        "bigdecimal\xC7\n\x0427:0.123e3\xD6\x00hash\x81\xD4\x00a\x91\xD4\x00a".b,
-    ))
+    V1_PAYLOAD = "\x87\xC7\x06\x00symbol\xC7\x06\x00symbol\xC7\x06\x00string\xA6string\xC7\x05\x00array\x92" \
+      "\xD4\x00a\xA1b\xD6\x00time\xC7\a\v\xCE8m`\x1A\x00\x00\xD7\x00datetime\xC7\v\f\xCD\a\xD0\x01\x01\x04" \
+      "\x05\x06\x01\x00\x01\xD6\x00date\xD6\x03\xD0\a\x01\x01\xD6\x00hash\x81\xD4\x00a\x91\xD4\x00a".b.freeze
+
+    ObjectOne = Struct.new(:foo, :bar) do
+      def as_pack
+        [foo, bar]
+      end
+
+      def self.from_pack(payload)
+        new(*payload)
+      end
+    end
+
+    ObjectTwo = Struct.new(:baz, :qux) do
+      def as_pack
+        members.zip(values).to_h
+      end
+
+      def self.from_pack(payload)
+        new(payload[:baz], payload[:qux])
+      end
+    end
+
+    def self.included(base = nil, &block)
+      if base && !block_given?
+        base.class_eval(&@included)
+      elsif base.nil? && block_given?
+        @included = block
+      else
+        raise "Can't pass both a base and and block"
+      end
+    end
+
+    included do
+      test "correctly encodes Symbol objects" do
+        codec = Paquito::CodecFactory.build([Symbol])
+
+        assert_equal("\xC7\x05\x00hello".b, codec.dump(:hello))
+        assert_equal(:hello, codec.load(codec.dump(:hello)))
+      end
+
+      test "correctly encodes Time objects" do
+        codec = Paquito::CodecFactory.build([Time])
+
+        value = Time.at(Rational(1_486_570_508_539_759, 1_000_000)).utc
+        encoded_value = codec.dump(value)
+        assert_equal("\xC7\f\x01oW\x18+\aH\x05\x00@B\x0F\x00".b, encoded_value)
+        recovered_value = codec.load(encoded_value)
+        assert_equal(value.nsec, recovered_value.nsec)
+        assert_equal(value, recovered_value)
+      end
+
+      test "does not mutate Time objects" do
+        time = Time.at(1_671_439_400, in: "+12:30")
+        time_state = time.inspect
+        assert_equal time_state, time.inspect
+        @codec.dump(time)
+        assert_equal time_state, time.inspect
+      end
+
+      test "correctly encodes DateTime objects" do
+        codec = Paquito::CodecFactory.build([DateTime])
+
+        value = DateTime.new(2017, 2, 8, 11, 25, 12.571685, "EST")
+        encoded_value = codec.dump(value)
+        assert_equal("\xC7\x14\x02\xE1\a\x02\b\v\x19\xA1]&\x00\x00\x00\x00\x00@\r\x03\x00\xFB\x18".b, encoded_value)
+        assert_equal(value, codec.load(encoded_value))
+
+        now = DateTime.now
+        assert_equal(now, codec.load(codec.dump(now)))
+      end
+
+      test "correctly encodes Date objects" do
+        codec = Paquito::CodecFactory.build([Date])
+
+        value = Date.new(2017, 2, 8)
+        encoded_value = codec.dump(value)
+        assert_equal("\xD6\x03\xE1\a\x02\b".b, encoded_value)
+        recovered_value = codec.load(encoded_value)
+        assert_equal(value, recovered_value)
+      end
+      test "BigDecimal serialization is stable" do
+        assert_equal(
+          BIG_DECIMAL_PAYLOAD,
+          @codec.dump(BigDecimal(123)),
+        )
+
+        assert_equal(
+          BigDecimal(123),
+          @codec.load(RUBY_3_0_BIG_DECIMAL),
+        )
+
+        assert_equal(
+          BigDecimal(123),
+          @codec.load(RUBY_3_1_BIG_DECIMAL),
+        )
+      end
+
+      test "reject malformed payloads with Paquito::PackError" do
+        assert_raises Paquito::UnpackError do
+          @codec.load("\x00\x00")
+        end
+      end
+
+      test "correctly encodes BigDecimal objects" do
+        codec = Paquito::CodecFactory.build([BigDecimal])
+
+        value = BigDecimal("123456789123456789.123456789123456789")
+        encoded_value = codec.dump(value)
+        assert_equal("\xC7,\x0445:0.123456789123456789123456789123456789e18".b, encoded_value)
+        recovered_value = codec.load(encoded_value)
+        assert_equal(value, recovered_value)
+      end
+
+      test "correctly encodes Set objects" do
+        codec = Paquito::CodecFactory.build([Set])
+
+        value = Set.new([1, 2, [3, 4, Set.new([5])]])
+        encoded_value = codec.dump(value)
+        assert_equal "\xC7\n\t\x93\x01\x02\x93\x03\x04\xD5\t\x91\x05".b, encoded_value
+
+        recovered_value = codec.load(encoded_value)
+        assert_equal(value, recovered_value)
+      end
+
+      test "supports freeze on load" do
+        # without extra types
+        codec = Paquito::CodecFactory.build([])
+        assert_equal(false, codec.load(codec.dump("foo")).frozen?)
+
+        codec = Paquito::CodecFactory.build([], freeze: true)
+        assert_equal(true, codec.load(codec.dump("foo")).frozen?)
+
+        # with extra types
+        codec = Paquito::CodecFactory.build([BigDecimal])
+        assert_equal(false, codec.load(codec.dump("foo")).frozen?)
+
+        codec = Paquito::CodecFactory.build([BigDecimal], freeze: true)
+        assert_equal(true, codec.load(codec.dump("foo")).frozen?)
+      end
+
+      test "does not enforce strictness of Hash type without serializable_type option" do
+        codec = Paquito::CodecFactory.build([])
+
+        type_subclass = Class.new(Hash)
+        object = type_subclass.new
+
+        assert_equal Hash, codec.load(codec.dump(object)).class
+      end
+
+      test "enforces strictness of Hash type with serializable_type option" do
+        codec = Paquito::CodecFactory.build([], serializable_type: true)
+
+        type_subclass = Class.new(Hash)
+        object = type_subclass.new
+
+        assert_raises(Paquito::PackError) { codec.dump(object) }
+      end
+
+      test "rejects unknown types with Paquito::PackError" do
+        codec = Paquito::CodecFactory.build([])
+        assert_raises(Paquito::PackError) do
+          codec.dump(Time.now)
+        end
+      end
+
+      test "rejects undeclared types with serializable_type option" do
+        codec = Paquito::CodecFactory.build([], serializable_type: true)
+
+        undeclared_type = Class.new(Object) do
+          def to_msgpack(_)
+          end
+        end
+        object = undeclared_type.new
+
+        assert_raises(Paquito::PackError) { codec.dump(object) }
+      end
+
+      test "serializes any object defining Object#as_pack and Object.from_pack with serializable_type option" do
+        codec = Paquito::CodecFactory.build([Symbol], serializable_type: true)
+
+        object = ObjectOne.new(
+          "foo",
+          { "bar" => ObjectTwo.new("baz", "qux") },
+        )
+        decoded = codec.load(codec.dump(object))
+        assert_equal object, decoded
+      end
+
+      test "handles class name changes by raising defined exception" do
+        codec = Paquito::CodecFactory.build([Symbol], serializable_type: true)
+
+        klass = ObjectOne
+        object = ObjectOne.new("foo", "bar")
+        serial = codec.dump(object)
+
+        begin
+          SharedCodecFactoryTests.send(:remove_const, :ObjectOne)
+          assert_raises(Paquito::ClassMissingError) do
+            codec.load(serial)
+          end
+        ensure
+          SharedCodecFactoryTests.const_set(:ObjectOne, klass) unless SharedCodecFactoryTests.const_defined?(:ObjectOne)
+        end
+      end
+
+      test "MessagePack errors are encapsulated" do
+        error = assert_raises(Paquito::PackError) do
+          @codec.dump(2**128)
+        end
+        assert_equal "RangeError, bignum too big to convert into `unsigned long long'", error.message
+
+        payload = @codec.dump("foo")
+        error = assert_raises(Paquito::UnpackError) do
+          @codec.load(payload.byteslice(0..-2))
+        end
+        assert_equal "EOFError, end of buffer reached", error.message
+      end
+
+      if defined? MessagePack::Bigint
+        test "bigint support" do
+          @codec = Paquito::CodecFactory.build([Integer])
+          bigint = 2**150
+          assert_equal bigint, @codec.load(@codec.dump(bigint))
+        end
+      end
+
+      test "loading of V0 types is stable" do
+        assert_equal(OBJECTS, @codec.load(V0_PAYLOAD))
+      end
+
+      test "loading of V1 types is stable" do
+        assert_equal(OBJECTS, @codec.load(V1_PAYLOAD))
+      end
+    end
   end
 
-  if defined? MessagePack::Bigint
-    test "bigint support" do
-      @codec = Paquito::CodecFactory.build([Integer])
-      bigint = 2**150
-      assert_equal bigint, @codec.load(@codec.dump(bigint))
+  class CodecFactoryV0Test < PaquitoTest
+    include SharedCodecFactoryTests
+
+    def setup
+      @codec = Paquito::CodecFactory.build([Symbol, Time, DateTime, Date, BigDecimal], pool: 1, format_version: 0)
+    end
+
+    test "issue#26 version 0 Time serializer may break if denominator is too big" do
+      time = Time.at(Rational(1, 2**33))
+
+      assert_raises Paquito::PackError do
+        @codec.dump(time)
+      end
+
+      assert_raises Paquito::UnpackError do
+        @codec.load("\xC7\f\x01\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00")
+      end
+    end
+
+    test "dumping of V0 types is stable" do
+      assert_equal(V0_PAYLOAD, @codec.dump(OBJECTS))
+    end
+  end
+
+  class CodecFactoryV1Test < PaquitoTest
+    include SharedCodecFactoryTests
+
+    def setup
+      @codec = Paquito::CodecFactory.build([Symbol, Time, DateTime, Date, BigDecimal], pool: 1, format_version: 1)
+    end
+
+    test "preserve Time#zone" do
+      with_env("TZ", "EST") do
+        now = Time.now
+        assert_equal "EST", now.zone
+        time_state = now.inspect
+        time_copy = @codec.load(@codec.dump(now))
+        assert_equal time_state, time_copy.inspect
+
+        skip("Time#zone can't be restored https://bugs.ruby-lang.org/issues/19253")
+        assert_equal "EST", time_copy.zone
+      end
+    end
+
+    test "dumping of V1 types is stable" do
+      assert_equal(V1_PAYLOAD, @codec.dump(OBJECTS))
     end
   end
 end


### PR DESCRIPTION
Fix: https://github.com/Shopify/paquito/issues/26
Alternative to https://github.com/Shopify/paquito/pull/28

We use an uint32 to store `time.to_r.denominator`, but this is incorrect as the denominator can be of any size.

Additionally we serialize it with `Array#pack` which silently ignore bits out of the range: https://bugs.ruby-lang.org/issues/19245

```ruby
>> [2**32].pack("L>").unpack("L>")
=> [0]
>> [2**32 + 12].pack("L>").unpack("L>")
=> [12]
```

We can solve this by using a recursive serializer, the multiple integers composing a `Time` instance are now serialized by msgpack which handle 64bit integers natively, and also optionally handle arbitrary size big ints.

Another issue I noticed is that we always store Time instance in UTC. This is generally what you want, but I think is a dangerious behavior and we'd be better to be as precise as possible.

So we now persist and restore the `utc_offset` in msgpack. However after investigating I couldn't find a way to restore the `#zone` attribute. None of the `Time` constructors allow this. But I think it's OK for now as this attribute is never really used and not really usable either.

To allow for a safe rollout however, we need to allow to first deploy with the capability to read the older formats but without writing them. For that purpose we introduce `Paquito.format_version` which control which version of the serializer is used for writing.