### PR TITLE
Update README.md to indicate Sorbet -> Paquito load order

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ coder.load(coder.dump(%i(foo bar).to_set)) # => #<Set: {:foo, :bar}>
 ### `TypedStruct`
 
 `Paquito::TypedStruct` is a opt-in Sorbet runtime plugin that allows `T::Struct` classes to be serializable. You need
-to explicitly include the module in the `T::Struct` classes that you will be serializing.
+to explicitly include the module in the `T::Struct` classes that you will be serializing. Also, Paquito must be added after Sorbet in your Gemfile for this constant to be available.
 
 Example
 


### PR DESCRIPTION
Paquito only loads Sorbet plugins if the Sorbet constant `T::Props` has already been defined/loaded. You must add Paquito after Sorbet in your Gemfile. If not Sorbet thinks the `Paquito::TypedStruct` constant is available but at runtime you'll get a `uninitialized constant Paquito::TypedStruct (NameError)`.

See:
https://github.com/Shopify/paquito/blob/8423314d08844163f036fdf0aca6f6973d770306/lib/paquito/typed_struct.rb#L4

I've updated the Readme to clarify this.