### PR TITLE
Attempt to load `active_support/core_ext/time/calculations`

### DIFF
--- a/lib/paquito/types.rb
+++ b/lib/paquito/types.rb
@@ -2,6 +2,14 @@
 
 require "paquito/errors"
 
+begin
+  require "active_support/core_ext/time/calculations"
+rescue LoadError
+  # We don't actually depend on ActiveSupport, we just want to use
+  # Time.at_without_coercion if it's available. Otherwise, we'll just use
+  # Time.at and ignore this error.
+end
+
 module Paquito
   module Types
     autoload :ActiveRecordPacker, "paquito/types/active_record_packer"


### PR DESCRIPTION
The optimization to use `Time.at_without_coercion` requires that we load `active_support/core_ext/time/calculations` before the respective methods are defined. I noticed this when examining some profiles. This behavior occurred on a non-Rails app, so I don't think most folks are affected, but figured the fix was best to do here regardless.

<img width="335" alt="image" src="https://github.com/user-attachments/assets/4d88ca58-0241-4b58-8583-3ec07376036b">
