### PR TITLE
Encode digest of column names + types along with records

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# Unreleased
+
+BREAKING CHANGE: ensure you have updated and deployed 0.11.3 before upgrading.
+
+* Store md5 digest of columns + sql types along with records (#51)
+
 # 0.11.3
 
 * Deserialize records with extra unused array elements in payload (#52)

--- a/lib/paquito/active_record_coder.rb
+++ b/lib/paquito/active_record_coder.rb
@@ -88,9 +88,7 @@ module Paquito
       end
 
       def serialize_record(record)
-        arguments = [record.class.name, attributes_for_database(record)]
-        arguments << true if record.new_record?
-        arguments
+        [record.class.name, attributes_for_database(record), record.new_record?]
       end
 
       def attributes_for_database(record)

--- a/test/activerecord/codec_factory_active_record_test.rb
+++ b/test/activerecord/codec_factory_active_record_test.rb
@@ -23,10 +23,10 @@ class PaquitoCodecFactoryActiveRecordTest < PaquitoTest
     assert_equal(shop, codec.load(reencoded_value))
   end
 
-  test "MessagePack factory preserves previous encoding scheme" do
+  test "MessagePack factory supports legacy encoding scheme without columns hash" do
     shop = Shop.preload(:products, :domain).first
 
-    payload = "\xC8\x01\x1A\x06\x95\x92\x00\x92\x92\xC7\x06\x00domain\x92\x01\x91\x92\xD6\x00"\
+    payload_without_columns_hash = "\xC8\x01\x1A\x06\x95\x92\x00\x92\x92\xC7\x06\x00domain\x92\x01\x91\x92\xD6\x00"\
       "shop\x00\x92\xD7\x00products\x92\x92\x02\x91\x92\xD6\x00shop\x00\x92\x03\x91\x92\xD6\x00"\
       "shop\x00\x92\xA4Shop\x84\xA2id\x01\xA4name\xAASnow Devil\xA8settings\xC4\x18#\xE2\x98\xA0"\
       "1\xE2\x98\xA2\n\x81\xD7\x00currency\xA3\xE2\x82\xAC\xA8owner_id\xC0\x92\xA6Domain\x83\xA7"\
@@ -35,7 +35,7 @@ class PaquitoCodecFactoryActiveRecordTest < PaquitoTest
       "\xB3Expensive Snowboard\xA8quantity\x02".b
 
     codec = Paquito::CodecFactory.build([ActiveRecord::Base])
-    recovered_value = codec.load(payload)
+    recovered_value = codec.load(payload_without_columns_hash)
 
     assert_equal(shop, recovered_value)
 
@@ -44,7 +44,17 @@ class PaquitoCodecFactoryActiveRecordTest < PaquitoTest
 
     encoded_value = codec.dump(shop)
 
-    assert_equal(payload, encoded_value)
+    assert_equal(shop, codec.load(encoded_value))
+
+    payload_with_columns_hash = "\xC8\x01\x1E\x06\x95\x92\x00\x92\x92\xC7\x06\x00domain\x92\x01\x91\x92\xD6\x00"\
+      "shop\x00\x92\xD7\x00products\x92\x92\x02\x91\x92\xD6\x00shop\x00\x92\x03\x91\x92\xD6\x00shop\x00"\
+      "\x93\xA4Shop\x84\xA2id\x01\xA4name\xAASnow Devil\xA8settings\xC4\x18#\xE2\x98\xA01\xE2\x98\xA2"\
+      "\n\x81\xD7\x00currency\xA3\xE2\x82\xAC\xA8owner_id\xC0\xC2\x93\xA6Domain\x83\xA7shop_id\x01\xA2id"\
+      "\x01\xA4name\xABexample.com\xC2\x93\xA7Product\x84\xA7shop_id\x01\xA2id\x01\xA4name\xAFCheap Snowboard"\
+      "\xA8quantity\x18\xC2\x93\xA7Product\x84\xA7shop_id\x01\xA2id\x02\xA4name\xB3Expensive Snowboard\xA8"\
+      "quantity\x02\xC2".b
+
+    assert_equal(payload_with_columns_hash, encoded_value)
   end
 
   test "MessagePack factory handles serialized records with more elements" do

--- a/test/activerecord/codec_factory_active_record_test.rb
+++ b/test/activerecord/codec_factory_active_record_test.rb
@@ -23,7 +23,7 @@ class PaquitoCodecFactoryActiveRecordTest < PaquitoTest
     assert_equal(shop, codec.load(reencoded_value))
   end
 
-  test "MessagePack factory supports legacy encoding scheme without columns hash" do
+  test "MessagePack factory supports encoding scheme either with or without columns hash" do
     shop = Shop.preload(:products, :domain).first
 
     payload_without_columns_hash = "\xC8\x01\x1A\x06\x95\x92\x00\x92\x92\xC7\x06\x00domain\x92\x01\x91\x92\xD6\x00"\
@@ -46,15 +46,16 @@ class PaquitoCodecFactoryActiveRecordTest < PaquitoTest
 
     assert_equal(shop, codec.load(encoded_value))
 
-    payload_with_columns_hash = "\xC8\x01\x1E\x06\x95\x92\x00\x92\x92\xC7\x06\x00domain\x92\x01\x91\x92\xD6\x00"\
-      "shop\x00\x92\xD7\x00products\x92\x92\x02\x91\x92\xD6\x00shop\x00\x92\x03\x91\x92\xD6\x00shop\x00"\
-      "\x93\xA4Shop\x84\xA2id\x01\xA4name\xAASnow Devil\xA8settings\xC4\x18#\xE2\x98\xA01\xE2\x98\xA2"\
-      "\n\x81\xD7\x00currency\xA3\xE2\x82\xAC\xA8owner_id\xC0\xC2\x93\xA6Domain\x83\xA7shop_id\x01\xA2id"\
-      "\x01\xA4name\xABexample.com\xC2\x93\xA7Product\x84\xA7shop_id\x01\xA2id\x01\xA4name\xAFCheap Snowboard"\
-      "\xA8quantity\x18\xC2\x93\xA7Product\x84\xA7shop_id\x01\xA2id\x02\xA4name\xB3Expensive Snowboard\xA8"\
-      "quantity\x02\xC2".b
+    payload_with_columns_hash = "\xC8\x01*\x06\x95\x92\x00\x92\x92\xC7\x06\x00domain\x92\x01\x91\x92\xD6\x00shop"\
+      "\x00\x92\xD7\x00products\x92\x92\x02\x91\x92\xD6\x00shop\x00\x92\x03\x91\x92\xD6\x00shop\x00\x94\xA4Shop"\
+      "\x84\xA2id\x01\xA4name\xAASnow Devil\xA8settings\xC4\x18#\xE2\x98\xA01\xE2\x98\xA2\n\x81\xD7\x00currency\xA3"\
+      "\xE2\x82\xAC\xA8owner_id\xC0\xC2\xCD>\xAD\x94\xA6Domain\x83\xA7shop_id\x01\xA2id\x01\xA4name\xABexample.com"\
+      "\xC2\xCD\x14\x16\x94\xA7Product\x84\xA7shop_id\x01\xA2id\x01\xA4name\xAFCheap Snowboard\xA8quantity\x18\xC2"\
+      "\xD1\x9DF\x94\xA7Product\x84\xA7shop_id\x01\xA2id\x02\xA4name\xB3Expensive Snowboard\xA8quantity\x02\xC2\xD1"\
+      "\x9DF".b
 
     assert_equal(payload_with_columns_hash, encoded_value)
+    assert_equal(shop, codec.load(payload_with_columns_hash))
   end
 
   test "MessagePack factory handles serialized records with more elements" do


### PR DESCRIPTION
Note: we need to ship a minor release changing our current `ActiveRecordCoder` to safely deserialize payloads with more than 3 elements before we can ship this PR. See https://github.com/Shopify/paquito/pull/52.

We can then ship this as a minor version bump to 0.12.0 maybe with a bundler warning that users should first upgrade to the latest patch release and ensure they are fully deployed before bumping to 0.12.0.

---

Currently when we encode a record, we store:

1. the record's class name
2. the record's attributes, as taken from `attributes_for_database`
3. (optionally) whether the record is new (`record.new_record?`)

The problem we have encountered is that when loading back the serialized values, a class may have gained/lost columns or had their types change, in which case it may fail with the serialized attributes in `attributes_for_database`.

To avoid this, I'm making the third, currently optional new record boolean required for new payloads, and adding a fourth: an md5 digset of the column names and their `sql_type` values.

When we load back the serialized record, _if_ the fourth argument is encoded in the payload, we compare it against the current hash to ensure that no columns have changed in any way. If they have, we raise a `ColumnsHashMismatch` error which can be caught to treat the fetch as a cache miss.