### PR TITLE
Deserialize records with extra unused array elements in payload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 # 0.11.2
 
+* Deserialize records with extra unused array elements in payload (#52)
 * Attempt to load `active_support/core_ext/time/calculations` before `Paquito::Types.time_unpack` is defined (#47)
 
 # 0.11.1

--- a/lib/paquito/active_record_coder.rb
+++ b/lib/paquito/active_record_coder.rb
@@ -99,7 +99,7 @@ module Paquito
         attributes
       end
 
-      def deserialize_record(class_name, attributes_from_database, new_record = false)
+      def deserialize_record(class_name, attributes_from_database, new_record = false, *)
         begin
           klass = Object.const_get(class_name)
         rescue NameError

--- a/test/activerecord/codec_factory_active_record_test.rb
+++ b/test/activerecord/codec_factory_active_record_test.rb
@@ -47,6 +47,23 @@ class PaquitoCodecFactoryActiveRecordTest < PaquitoTest
     assert_equal(payload, encoded_value)
   end
 
+  test "MessagePack factory handles serialized records with more elements" do
+    shop = Shop.preload(:products, :domain).first
+
+    payload = "\xC8\x01*\x06\x95\x92\x00\x92\x92\xC7\x06\x00domain\x92\x01\x91\x92\xD6\x00shop"\
+      "\x00\x92\xD7\x00products\x92\x92\x02\x91\x92\xD6\x00shop\x00\x92\x03\x91\x92\xD6\x00shop\x00\x94\xA4Shop"\
+      "\x84\xA2id\x01\xA4name\xAASnow Devil\xA8settings\xC4\x18#\xE2\x98\xA01\xE2\x98\xA2\n\x81\xD7\x00currency\xA3"\
+      "\xE2\x82\xAC\xA8owner_id\xC0\xC2\xCD>\xAD\x94\xA6Domain\x83\xA7shop_id\x01\xA2id\x01\xA4name\xABexample.com"\
+      "\xC2\xCD\x14\x16\x94\xA7Product\x84\xA7shop_id\x01\xA2id\x01\xA4name\xAFCheap Snowboard\xA8quantity\x18\xC2"\
+      "\xD1\x9DF\x94\xA7Product\x84\xA7shop_id\x01\xA2id\x02\xA4name\xB3Expensive Snowboard\xA8quantity\x02\xC2\xD1"\
+      "\x9DF".b
+
+    codec = Paquito::CodecFactory.build([ActiveRecord::Base])
+    recovered_value = codec.load(payload)
+
+    assert_equal(shop, recovered_value)
+  end
+
   test "MessagePack factory handle binary columns in AR::Base objects" do
     model = Shop.first
     assert_instance_of ::ActiveModel::Type::Binary::Data, model.attributes_for_database.fetch("settings")


### PR DESCRIPTION
This is preparation for https://github.com/Shopify/paquito/pull/51.

This simply makes our `ActiveRecordCoder` not blow up if the payload for a record contains more elements than we expect. Once we ship this, applications can upgrade their patch version to this, ensure they are fully deployed, _then_ upgrade to 0.12.0 which will contain https://github.com/Shopify/paquito/pull/51.