### PR TITLE
Release v1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,16 @@
 # 1.0.0
 
+Both changes in this release require applications to be fully updated to the latest patch version of the gem before
+bumping to this version.
+
 * Store md5 digest of columns + sql types along with records (#51)
-  *IMPORTANT*: ensure you have updated and deployed 0.11.3 before upgrading, and ensure you are handling either
-  all `ActiveRecordCoder::Error` errors, or that you explicitly add `ActiveRecordCoder::ColumnsDigestMismatch`
-  to your error handling.
+  *IMPORTANT*: if you are storing Active Record objects in the cache, ensure you have updated and deployed 0.11.3 before
+  upgrading, and ensure you are handling either all `ActiveRecordCoder::Error` errors, or that you explicitly add
+  `ActiveRecordCoder::ColumnsDigestMismatch` to your error handling.
+* Bump `Paquito.format_version` to `1` by default.
+  *IMPORTANT*: if you are upgrading from a previous version, you MUST first fully deploy the gem up to at least version 0.10.0
+  and release before enabling it. If you don't, you may notice some `UnpackError` during the code rollout, which may be fine
+  if you only use Paquito for ephemeral cache data. See release notes for v0.10.0.
 
 # 0.11.3
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# Unreleased
+# 1.0.0
 
 BREAKING CHANGE: ensure you have updated and deployed 0.11.3 before upgrading.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,9 @@
 # 1.0.0
 
-BREAKING CHANGE: ensure you have updated and deployed 0.11.3 before upgrading.
-
 * Store md5 digest of columns + sql types along with records (#51)
+  *IMPORTANT*: ensure you have updated and deployed 0.11.3 before upgrading, and ensure you are handling either
+  all `ActiveRecordCoder::Error` errors, or that you explicitly add `ActiveRecordCoder::ColumnsDigestMismatch`
+  to your error handling.
 
 # 0.11.3
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    paquito (0.11.3)
+    paquito (1.0.0)
       msgpack (>= 1.5.2)
 
 GEM

--- a/lib/paquito.rb
+++ b/lib/paquito.rb
@@ -29,7 +29,7 @@ module Paquito
   autoload :FlatCacheEntryCoder, "paquito/flat_cache_entry_coder"
   autoload :ActiveRecordCoder, "paquito/active_record_coder"
 
-  DEFAULT_FORMAT_VERSION = 0
+  DEFAULT_FORMAT_VERSION = 1
   @format_version = DEFAULT_FORMAT_VERSION
 
   class << self

--- a/lib/paquito/version.rb
+++ b/lib/paquito/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Paquito
-  VERSION = "0.11.3"
+  VERSION = "1.0.0"
 end

--- a/paquito.gemspec
+++ b/paquito.gemspec
@@ -22,7 +22,9 @@ Gem::Specification.new do |spec|
   spec.post_install_message = <<~POST_INSTALL_MSG
     Warning: Paquito 1.0 includes potentially breaking changes to ActiveRecordCoder.
     Before upgrading to 1.0 from an earlier version, ensure you have first upgraded
-    to 0.11.3 and deployed your application before upgrading to 1.0.
+    to 0.11.3 and deployed your application before upgrading to 1.0. Also ensure you
+    rescue either all `ActiveRecordCoder::Error` errors, or that you explicitly
+    rescue the new `ActiveRecord::ColumnsDigestError`.
   POST_INSTALL_MSG
 
   # Specify which files should be added to the gem when it is released.

--- a/paquito.gemspec
+++ b/paquito.gemspec
@@ -19,6 +19,12 @@ Gem::Specification.new do |spec|
   spec.metadata["homepage_uri"] = spec.homepage
   spec.metadata["source_code_uri"] = "https://github.com/Shopify/paquito"
 
+  spec.post_install_message = <<~POST_INSTALL_MSG
+    Warning: Paquito 1.0 includes potentially breaking changes to ActiveRecordCoder.
+    Before upgrading to 1.0 from an earlier version, ensure you have first upgraded
+    to 0.11.3 and deployed your application before upgrading to 1.0.
+  POST_INSTALL_MSG
+
   # Specify which files should be added to the gem when it is released.
   # The `git ls-files -z` loads the files in the RubyGem that have been added into git.
   spec.files = Dir.chdir(File.expand_path(__dir__)) do

--- a/test/vanilla/codec_factory_test.rb
+++ b/test/vanilla/codec_factory_test.rb
@@ -71,7 +71,7 @@ module Paquito
 
         value = Time.at(Rational(1_486_570_508_539_759, 1_000_000)).utc
         encoded_value = codec.dump(value)
-        assert_equal("\xC7\f\x01oW\x18+\aH\x05\x00@B\x0F\x00".b, encoded_value)
+        assert_equal("\xC7\v\v\xCEX\x9BD\f\xCE ,\x11\x98\x00".b, encoded_value)
         recovered_value = codec.load(encoded_value)
         assert_equal(value.nsec, recovered_value.nsec)
         assert_equal(value, recovered_value)
@@ -90,7 +90,7 @@ module Paquito
 
         value = DateTime.new(2017, 2, 8, 11, 25, 12.571685, "EST")
         encoded_value = codec.dump(value)
-        assert_equal("\xC7\x14\x02\xE1\a\x02\b\v\x19\xA1]&\x00\x00\x00\x00\x00@\r\x03\x00\xFB\x18".b, encoded_value)
+        assert_equal("\xC7\x13\f\xCD\a\xE1\x02\b\v\x19\xCE\x00&]\xA1\xCE\x00\x03\r@\xFB\x18".b, encoded_value)
         assert_equal(value, codec.load(encoded_value))
 
         now = DateTime.now


### PR DESCRIPTION
Includes: https://github.com/Shopify/paquito/pull/51, which is a potentially breaking change. I added a post-install message warning folks about this and what to do to avoid issues.