### PR TITLE
Cache columns_digest on class

### DIFF
--- a/lib/paquito.rb
+++ b/lib/paquito.rb
@@ -56,3 +56,11 @@ module Paquito
     end
   end
 end
+
+if defined? ActiveSupport
+  ActiveSupport.on_load(:active_record) do
+    require "paquito/columns_digest_cache"
+
+    include Paquito::ColumnsDigestCache
+  end
+end

--- a/lib/paquito/active_record_coder.rb
+++ b/lib/paquito/active_record_coder.rb
@@ -22,6 +22,15 @@ module Paquito
         deserialize_associations(serialized_associations, instances)
       end
 
+      def columns_digest(klass)
+        str = +""
+        klass.columns_hash.each do |name, column|
+          str << "," unless str.empty?
+          str << name << ":" << column.sql_type
+        end
+        ::Digest::MD5.digest(str).unpack1("s")
+      end
+
       private
 
       # Records without associations, or which have already been visited before,
@@ -92,7 +101,7 @@ module Paquito
           record.class.name,
           attributes_for_database(record),
           record.new_record?,
-          columns_digest(record.class),
+          record.class.paquito_columns_digest,
         ]
       end
 
@@ -109,7 +118,7 @@ module Paquito
           raise ClassMissingError, "undefined class: #{class_name}"
         end
 
-        if hash && (hash != (expected_digest = columns_digest(klass)))
+        if hash && (hash != (expected_digest = klass.paquito_columns_digest))
           raise ColumnsDigestMismatch,
             "\"#{hash}\" does not match the expected digest of \"#{expected_digest}\""
         end
@@ -118,15 +127,6 @@ module Paquito
         # wether the record was persisted or not.
         attributes = klass.attributes_builder.build_from_database(attributes_from_database, EMPTY_HASH)
         klass.allocate.init_with_attributes(attributes, new_record)
-      end
-
-      def columns_digest(klass)
-        str = +""
-        klass.columns_hash.each do |name, column|
-          str << "," unless str.empty?
-          str << name << ":" << column.sql_type
-        end
-        ::Digest::MD5.digest(str).unpack1("s")
       end
     end
 

--- a/lib/paquito/columns_digest_cache.rb
+++ b/lib/paquito/columns_digest_cache.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module Paquito
+  module ColumnsDigestCache
+    extend ActiveSupport::Concern
+
+    class_methods do
+      def reload_schema_from_cache(*)
+        super
+        @paquito_columns_digest = nil
+      end
+
+      def paquito_columns_digest
+        @paquito_columns_digest ||= Paquito::ActiveRecordCoder.columns_digest(self)
+      end
+    end
+  end
+end


### PR DESCRIPTION
We previously [improved][1] the speed of columns_digest by not allocating an intermediate array. However, columns_digest is still very hot in our application (~15% of time spent inside MessagePack::Unpacker#full_unpack).

This commit caches columns_digest on the model class by hooking into schema loading. Since the value is calculated from a model's columns_hash, this ensures that if the schema is reloaded the value is recalculated.

---

The benchmark in #67 shows a 2x speedup on dumping and loading an Active Record

```
$ ruby --yjit benchmark/active-record-unpack.rb
-- create_table(:records)
   -> 0.0110s
=== dump ===
ruby 4.0.2 (2026-03-17 revision d3da9fec82) +YJIT +PRISM [arm64-darwin23]
Warming up --------------------------------------
        dump (after)    20.603k i/100ms
Calculating -------------------------------------
        dump (after)    204.449k (± 0.4%) i/s    (4.89 μs/i) -      1.030M in   5.038761s

Comparison:
       dump (before):   104609.9 i/s
        dump (after):   204449.0 i/s - 1.95x  faster


=== load ===
ruby 4.0.2 (2026-03-17 revision d3da9fec82) +YJIT +PRISM [arm64-darwin23]
Warming up --------------------------------------
        load (after)    22.651k i/100ms
Calculating -------------------------------------
        load (after)    226.690k (± 0.4%) i/s    (4.41 μs/i) -      1.155M in   5.096033s

Comparison:
       load (before):   110229.1 i/s
        load (after):   226689.9 i/s - 2.06x  faster
```

[1]: https://github.com/Shopify/paquito/commit/5769fc2389ed4427db5f9c36603a46b17b99408b