### PR TITLE
Use recursive: true for custom types

### DIFF
--- a/lib/paquito/types.rb
+++ b/lib/paquito/types.rb
@@ -405,13 +405,13 @@ module Paquito
         factory.register_type(
           127,
           Object,
-          packer: ->(value) do
-            packer = CustomTypesRegistry.packer(value)
+          packer: ->(value, packer) do
+            as_pack = CustomTypesRegistry.packer(value)
             class_name = value.class.to_s
-            factory.dump([packer.call(value), class_name])
+            packer.write([as_pack.call(value), class_name])
           end,
-          unpacker: ->(value) do
-            payload, class_name = factory.load(value)
+          unpacker: ->(unpacker) do
+            payload, class_name = unpacker.read
 
             begin
               klass = Object.const_get(class_name)
@@ -419,9 +419,10 @@ module Paquito
               raise ClassMissingError, "missing #{class_name} class"
             end
 
-            unpacker = CustomTypesRegistry.unpacker(klass)
-            unpacker.call(payload)
+            from_pack = CustomTypesRegistry.unpacker(klass)
+            from_pack.call(payload)
           end,
+          recursive: true,
         )
       end
 


### PR DESCRIPTION
This enables them to re-use the current {un,}packer instead of having new {un,}packers allocated per call.

We apparently have some deeply nested (at least 6 deep) custom types where this will remove a bunch of overhead.